### PR TITLE
Setup handling without repo

### DIFF
--- a/src/lib/component.rs
+++ b/src/lib/component.rs
@@ -27,7 +27,7 @@ pub struct Component {
     pub path: Option<String>,
     pub color: TerminalColor,
     pub env: HashMap<String, String>,
-    pub repo: String,
+    pub repo: Option<String>,
     pub delay: Option<u64>,
     pub start: Command,
     pub init: Vec<Command>,
@@ -41,7 +41,7 @@ impl Default for Component {
             name: "Unknown".into(),
             path: None,
             env: HashMap::new(),
-            repo: "".into(),
+            repo: None,
             color: TerminalColor::Yellow,
             delay: None,
             start: Command::default(),
@@ -65,6 +65,12 @@ impl Component {
     }
 
     pub fn clone_repo(&self, root_path: &Path) -> Result<(), std::io::Error> {
-        git::clone_repo(&self.repo, root_path).map(|_| ())
+        match &self.repo {
+            Some(repo) => git::clone_repo(&repo, root_path).map(|_| ()),
+            None => Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Repo not specified",
+            )),
+        }
     }
 }

--- a/src/lib/system.rs
+++ b/src/lib/system.rs
@@ -219,11 +219,13 @@ pub fn setup_project(fname: &PathBuf) {
                 let mut cmp_path = root_path.clone();
                 cmp_path.push(cmp.get_path());
                 match cmp.clone_repo(&cmp_path) {
-                    Ok(_) => ui::system_message(format!("{} cloned", cmp.clone().name)),
+                    Ok(_) => {
+                        ui::system_message(format!("{} cloned", cmp.clone().name));
+                        for cmd in &cmp.init {
+                            run_command(&cmd, &cmp, &root_path);
+                        }
+                    }
                     Err(e) => ui::system_error(format!("Skipping clone: {}", e)),
-                }
-                for cmd in &cmp.init {
-                    run_command(&cmd, &cmp, &root_path);
                 }
             }
         }


### PR DESCRIPTION
When a repo is not specified the setup command did not gracefully handle
it.

Repo was changed to an Option in the component and setup errors
gracefully if it is not supplied.


----

#