### PR TITLE
Added default to components

### DIFF
--- a/src/lib/component.rs
+++ b/src/lib/component.rs
@@ -34,6 +34,7 @@ pub struct Component {
   pub init: Vec<Command>,
   pub tags: Vec<String>,
   pub retry: bool,
+  pub default: bool,
   pub services: Vec<String>,
 }
 
@@ -41,6 +42,7 @@ impl Default for Component {
   fn default() -> Self {
     Component {
       name: "Unknown".into(),
+      default: true,
       path: None,
       env: HashMap::new(),
       repo: None,

--- a/src/lib/system.rs
+++ b/src/lib/system.rs
@@ -258,10 +258,15 @@ pub fn run_project(fname: &PathBuf, tags: Option<Vec<&str>>) -> Result<(), Syste
     Some(t) => project
       .components
       .into_iter()
-      .filter(|x| x.has_tag(&t.clone()))
+      .filter(|x| x.has_tag(&t.clone()) || x.default == true)
       .map(|x| x.name)
       .collect(),
-    None => project.components.into_iter().map(|x| x.name).collect(),
+    None => project
+      .components
+      .into_iter()
+      .filter(|x| x.default == true)
+      .map(|x| x.name)
+      .collect(),
   };
   run_components(fname, component_names)
 }


### PR DESCRIPTION

A default value can be set to false to prevent a component from running when the entire stack is executed.